### PR TITLE
Update server.js (Https doesn't start on specified port)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -42,7 +42,8 @@ if (Argv.h) {
 config.server_port = Argv.p || Argv.port || Config.server_port || 2000;
 config.server_address = Argv.a || Argv.address || Config.server_address || 'localhost';
 config.bind_address = Argv.b || Argv.bind_address || Config.bind_address || '127.0.0.1';
-config.http_enabled = Argv.http_enabled || Config.http_enabled || true;
+config.http_enabled = Argv.http_enabled || Config.http_enabled;
+if (config.http_enabled === undefined) config.http_enabled = true
 
 /* Logging */
 config.log_level = Argv.log_level || Config.log_level || 'info';

--- a/server.js
+++ b/server.js
@@ -109,7 +109,7 @@ if (Config.https_enabled) {
 
     var https_server = Https.createServer(https_options, serveRequest);
 
-    https_server.listen(Config.server_port, Config.bind_address, function(){
+    https_server.listen(Config.https_port, Config.bind_address, function(){
         log.info('Lazy mirror (HTTPS) is listening @ ' + Config.bind_address + ':' + Config.https_port + ' External host: ' + Config.server_address);
     });
 }


### PR DESCRIPTION
Hello, 

Very nice piece of code, and so very useful.
Test it for few days now, and answer perfectly my need.

A little correction because of https_port config was not use correctly, and so create a Error: listen EADDRINUSE
if the http is enabled.

I stay tune on the github for new advice, pull request, bugs. 

Several things to test with https, https between node and npm-lazy-mirrror seems to be useful. Friday test seems to be not concluant.

Lucas
