### PR TITLE
Set default access to registry server in https

### DIFF
--- a/config/config-defaults.json
+++ b/config/config-defaults.json
@@ -3,7 +3,9 @@
     "server_address": "localhost",
 
     "upstream_host": "registry.npmjs.org",
-    "upstream_port": 80,
+    "upstream_port": 443,
+    "upstream_use_https": true,
+    "upstream_verify_ssl": true,
 
     "cache_dir": "/tmp/npm-lazy",
     "cache_mem": 200


### PR DESCRIPTION
Now, Npm has a real signed certificate for his registry.npmjs.org

I think npm-lazy-mirror default config should use https to connect.
