### PR TITLE
Correct path from global bin script to primary server module

### DIFF
--- a/bin/npm-lazy-mirror
+++ b/bin/npm-lazy-mirror
@@ -5,5 +5,5 @@
 #
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-node $DIR/../lib/node_modules/npm-lazy-mirror/server.js $@
+node $DIR/../server.js $@
 


### PR DESCRIPTION
Corrects relative path from command-line bin script to primary server module.

Fixes issue #14.
