### PR TITLE
Options and Documentation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This package provides a lazy mirroring option for those that:
 
 With CLI flags:
 
-  * `npm-lazy-mirror -p <port> -a <remote_address> -b <bind_address> --cache-dir /npm-data`
+  * `npm-lazy-mirror -p <port> -a <remote_address> -b <bind_address> --cache_dir /npm-data`
 
 With a JSON configuration:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -16,28 +16,41 @@ var Optimist = require('optimist')
     a: 'The external DNS name this mirror should serve on',
     b: 'The local interface bind address',
     c: 'The full directory path the cache directory (no trailing slash)',
-    p: 'The HTTP port for the lazy mirror to listen on (default:2000)',
+    p: 'The HTTP port for the lazy mirror to listen on',
     C: 'The path to the JSON configuration file',
-    cache_expiry: 'Expire the upstream registry cache assets on this value (ms), default: 24 hours',
-    cache_mem: 'The maxmium size in MB of registry data to keep in memory. A larger allocation reduces disk hits and improves performance, default: 200',
+    cache_expiry: 'Expire the upstream registry cache assets on this value (ms)',
+    cache_mem: 'The maxmium size in MB of registry data to keep in memory. A larger allocation reduces disk hits and improves performance',
     cache_dir: 'The root directory path to store cache objects',
     config: 'The path to the JSON server configuration file',
     http_enabled: 'Enable the HTTP server on -p, this is true if neither --http_enabled or --https_enabled are supplied',
     https_enabled: 'Enable the HTTPS server on --https_port',
     https_key: 'The path to the private SSL key',
     https_cert: 'The path to the private SSL certificate',
-    https_port: 'The HTTPS port (requires --https_enabled), default: 443',
+    https_port: 'The HTTPS port (requires --https_enabled)',
     http_proxy: 'Specify a HTTP proxy to traverse before making outbound requests',
     https_proxy: 'Specify a HTTPS proxy to traverse before making outbound requests',
     package_blacklist: 'Full path to a JSON configuration file of blacklisted packages',
     permit_stale_resources: 'Continue to serve stale resources if the upstream registry cannot be contacted',
     real_external_port: 'If this mirror is behind a proxy, set this flag to the real external port for client connections',
     server_address: 'The external DNS name for connecting clients',
-    upstream_host: 'The upstream registry host, default: registry.npmjs.org',
-    upstream_port: 'The default upstream registry port, default: 80',
+    upstream_host: 'The upstream registry host',
+    upstream_port: 'The default upstream registry port',
     upstream_db_path: 'The default upstream registry database path, default: none (requires a leading slash)',
-    upstream_use_https: 'Use HTTPS only when proxying to the upstream registry, default: false',
-    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates, default: false'
+    upstream_use_https: 'Use HTTPS only when proxying to the upstream registry',
+    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates'
+})
+.default({
+    'a': 'localhost',
+    'b': '127.0.0.1',
+    'c': '/tmp/files',
+    'p': 2000,
+    'cache_expiry': 24 * 60 * 60 * 1000, // 24 Hours
+    'cache_mem': 200, // MB
+    'https_port': 443,
+    'upstream_host': 'registry.npmjs.org',
+    'upstream_port': 80,
+    'upstream_use_https': false,
+    'upstream_verify_ssl': false
 });
 
 var Argv = Optimist.argv,
@@ -57,13 +70,13 @@ if (Argv.h) {
 }
 
 /* Local server options */
-config.httpPort = Argv.p || Argv.port || Config.http_port || 2000;
-config.serverAddress = Argv.a || Argv.server_address || Config.server_address || 'localhost';
-config.bindAddress = Argv.b || Argv.bind_address || Config.bind_address || '127.0.0.1';
+config.httpPort = Argv.p || Argv.port || Config.http_port;
+config.serverAddress = Argv.a || Argv.server_address || Config.server_address;
+config.bindAddress = Argv.b || Argv.bind_address || Config.bind_address;
 config.httpEnabled = Argv.http_enabled || Config.http_enabled;
 
 /* Local server HTTPS options */
-config.httpsPort = Argv.https_port || Config.https_port || 443;
+config.httpsPort = Argv.https_port || Config.https_port;
 config.httpsEnabled = Argv.https_enabled || Config.https_enabled;
 
 if (!config.httpEnabled && !config.httpsEnabled) {
@@ -79,17 +92,17 @@ config.httpsKey = Argv.https_key || Config.https_key || null;
 config.httpsCert = Argv.https_cert || Config.https_cert || null;
 
 /* Upstream Registry */
-config.upstreamHost = Argv.upstream_host || Config.upstream_host || 'registry.npmjs.org';
-config.upstreamPort = Argv.upstream_port || Config.upstream_port || 80;
-config.upstreamUseHttps = Argv.upstream_use_https || Config.upstream_use_https || false;
-config.upstreamVerifySSL = Argv.upstream_verify_ssl || Config.upstream_verify_ssl || false;
+config.upstreamHost = Argv.upstream_host || Config.upstream_host;
+config.upstreamPort = Argv.upstream_port || Config.upstream_port;
+config.upstreamUseHttps = Argv.upstream_use_https || Config.upstream_use_https;
+config.upstreamVerifySSL = Argv.upstream_verify_ssl || Config.upstream_verify_ssl;
 config.upstreamDBPath = Argv.upstream_db_path || Config.upstream_db_path || '';
 
 /* Caching options */
 config.cache = {};
-config.cacheDir = Argv.c || Argv.cache_dir || Config.cache_dir || '/tmp/files';
-config.cacheExpiry = Argv.cache_expiry || Config.cache_expiry || 24 * 60 * 60 * 1000; // 24 Hours
-config.cacheMem = Argv.cache_mem || Config.cache_mem || 200; // MB
+config.cacheDir = Argv.c || Argv.cache_dir || Config.cache_dir;
+config.cacheExpiry = Argv.cache_expiry || Config.cache_expiry
+config.cacheMem = Argv.cache_mem || Config.cache_mem
 config.cacheOptions = {
     cache: {
         expire: 60 * 60,

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@ var Npm = require('npm');
 var FS = require('fs');
 
 var Optimist = require('optimist')
-.usage('Usage: $0 -p <port> -r <external_dns> -c <file cache dir>')
+.usage('Usage: $0 -p <port> -a <external_dns> -c <file cache dir>')
 .describe({
     a: 'The external DNS name this mirror should serve on',
     b: 'The local interface bind address',

--- a/lib/config.js
+++ b/lib/config.js
@@ -35,7 +35,9 @@ var Optimist = require('optimist')
     upstream_db_path: 'The default upstream registry database path, default: none (requires a leading slash)',
     upstream_use_https: 'Use HTTPS only when proxying to the upstream registry',
     upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates',
-    log_level: 'Logging level'
+    log_level: 'Logging level',
+    version: 'Print version and exit',
+    help: 'This help screen'
 })
 .default({
     'server_address': 'localhost',
@@ -56,7 +58,9 @@ var Optimist = require('optimist')
     'bind_address': 'b',
     'cache_dir': 'c',
     'http_port': 'p',
-    'config': 'C'
+    'config': 'C',
+    'version': 'v',
+    'help': 'h'
 });
 
 var Argv = Optimist.argv,

--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,7 @@ var Optimist = require('optimist')
     'server_address': 'a',
     'bind_address': 'b',
     'cache_dir': 'c',
-    'http_port': 'p',
+    'http_port': ['port','p'],
     'config': 'C',
     'version': 'v',
     'help': 'h'
@@ -67,22 +67,22 @@ var Argv = Optimist.argv,
     config = {};
 
 /* CLI specific */
-if (Argv.h) {
+if (Argv.help) {
     console.log(Optimist.help());
     process.exit();
 
-} else if (Argv.v) {
+} else if (Argv.version) {
     console.log('npm-lazy-mirror: ' + PackageJSON.version);
     process.exit();
 
-} else if (Argv.C || Argv.config) {
-    Config = JSON.parse(FS.readFileSync((Argv.C || Argv.config)));
+} else if (Argv.config) {
+    Config = JSON.parse(FS.readFileSync(Argv.config));
 }
 
 /* Local server options */
-config.httpPort = Argv.p || Argv.port || Config.http_port;
-config.serverAddress = Argv.a || Argv.server_address || Config.server_address;
-config.bindAddress = Argv.b || Argv.bind_address || Config.bind_address;
+config.httpPort = Argv.http_port || Config.http_port;
+config.serverAddress = Argv.server_address || Config.server_address;
+config.bindAddress = Argv.bind_address || Config.bind_address;
 config.httpEnabled = Argv.http_enabled || Config.http_enabled;
 
 /* Local server HTTPS options */
@@ -110,7 +110,7 @@ config.upstreamDBPath = Argv.upstream_db_path || Config.upstream_db_path || '';
 
 /* Caching options */
 config.cache = {};
-config.cacheDir = Argv.c || Argv.cache_dir || Config.cache_dir;
+config.cacheDir = Argv.cache_dir || Config.cache_dir;
 config.cacheExpiry = Argv.cache_expiry || Config.cache_expiry
 config.cacheMem = Argv.cache_mem || Config.cache_mem
 config.cacheOptions = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -34,7 +34,8 @@ var Optimist = require('optimist')
     upstream_port: 'The default upstream registry port',
     upstream_db_path: 'The default upstream registry database path, default: none (requires a leading slash)',
     upstream_use_https: 'Use HTTPS only when proxying to the upstream registry',
-    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates'
+    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates',
+    log_level: 'Logging level'
 })
 .default({
     'server_address': 'localhost',
@@ -47,7 +48,8 @@ var Optimist = require('optimist')
     'upstream_host': 'registry.npmjs.org',
     'upstream_port': 80,
     'upstream_use_https': false,
-    'upstream_verify_ssl': false
+    'upstream_verify_ssl': false,
+    'log_level': 'info'
 })
 .alias({
     'server_address': 'a',
@@ -90,7 +92,7 @@ if (!config.httpEnabled && !config.httpsEnabled) {
 config.realExternalPort = Argv.real_external_port || (config.httpsEnabled ? config.httpsPort : config.httpPort);
 
 /* Logging */
-config.logLevel = Argv.log_level || Config.log_level || 'info';
+config.logLevel = Argv.log_level || Config.log_level;
 
 config.httpsKey = Argv.https_key || Config.https_key || null;
 config.httpsCert = Argv.https_cert || Config.https_cert || null;

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,45 +13,31 @@ var FS = require('fs');
 var Optimist = require('optimist')
 .usage('Usage: $0 -p <port> -a <external_dns> -c <file cache dir>')
 .describe({
-    server_address: 'The external DNS name this mirror should serve on',
-    bind_address: 'The local interface bind address',
-    cache_dir: 'The full directory path the cache directory (no trailing slash)',
-    http_port: 'The HTTP port for the lazy mirror to listen on',
+    server_address: 'The external DNS name this mirror should serve on [default: localhost]',
+    bind_address: 'The local interface bind address [default: 127.0.0.1]',
+    cache_dir: 'The full directory path the cache directory (no trailing slash) [default: /tmp/files]',
+    http_port: 'The HTTP port for the lazy mirror to listen on [default: 2000]',
     config: 'The path to the JSON configuration file',
-    cache_expiry: 'Expire the upstream registry cache assets on this value (ms)',
-    cache_mem: 'The maxmium size in MB of registry data to keep in memory. A larger allocation reduces disk hits and improves performance',
+    cache_expiry: 'Expire the upstream registry cache assets on this value (ms) [default: 24 hours]',
+    cache_mem: 'The maxmium size in MB of registry data to keep in memory. A larger allocation reduces disk hits and improves performance [default: 200]',
     http_enabled: 'Enable the HTTP server on -p, this is true if neither --http_enabled or --https_enabled are supplied',
     https_enabled: 'Enable the HTTPS server on --https_port',
     https_key: 'The path to the private SSL key',
     https_cert: 'The path to the private SSL certificate',
-    https_port: 'The HTTPS port (requires --https_enabled)',
+    https_port: 'The HTTPS port (requires --https_enabled) [default: 443]',
     http_proxy: 'Specify a HTTP proxy to traverse before making outbound requests',
     https_proxy: 'Specify a HTTPS proxy to traverse before making outbound requests',
     package_blacklist: 'Full path to a JSON configuration file of blacklisted packages',
     permit_stale_resources: 'Continue to serve stale resources if the upstream registry cannot be contacted',
     real_external_port: 'If this mirror is behind a proxy, set this flag to the real external port for client connections',
-    upstream_host: 'The upstream registry host',
-    upstream_port: 'The default upstream registry port',
+    upstream_host: 'The upstream registry host [default: registry.npmjs.org]',
+    upstream_port: 'The default upstream registry port [default: 80]',
     upstream_db_path: 'The default upstream registry database path, default: none (requires a leading slash)',
-    upstream_use_https: 'Use HTTPS only when proxying to the upstream registry',
-    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates',
-    log_level: 'Logging level',
+    upstream_use_https: 'Use HTTPS only when proxying to the upstream registry [default: false]',
+    upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates [default: false]',
+    log_level: 'Logging level [default: info]',
     version: 'Print version and exit',
     help: 'This help screen'
-})
-.default({
-    'server_address': 'localhost',
-    'bind_address': '127.0.0.1',
-    'cache_dir': '/tmp/files',
-    'http_port': 2000,
-    'cache_expiry': 24 * 60 * 60 * 1000, // 24 Hours
-    'cache_mem': 200, // MB
-    'https_port': 443,
-    'upstream_host': 'registry.npmjs.org',
-    'upstream_port': 80,
-    'upstream_use_https': false,
-    'upstream_verify_ssl': false,
-    'log_level': 'info'
 })
 .alias({
     'server_address': 'a',
@@ -80,13 +66,13 @@ if (Argv.help) {
 }
 
 /* Local server options */
-config.httpPort = Argv.http_port || Config.http_port;
-config.serverAddress = Argv.server_address || Config.server_address;
-config.bindAddress = Argv.bind_address || Config.bind_address;
+config.httpPort = Argv.http_port || Config.http_port || 2000;
+config.serverAddress = Argv.server_address || Config.server_address || 'localhost';
+config.bindAddress = Argv.bind_address || Config.bind_address || '127.0.0.1';
 config.httpEnabled = Argv.http_enabled || Config.http_enabled;
 
 /* Local server HTTPS options */
-config.httpsPort = Argv.https_port || Config.https_port;
+config.httpsPort = Argv.https_port || Config.https_port || 443;
 config.httpsEnabled = Argv.https_enabled || Config.https_enabled;
 
 if (!config.httpEnabled && !config.httpsEnabled) {
@@ -96,23 +82,23 @@ if (!config.httpEnabled && !config.httpsEnabled) {
 config.realExternalPort = Argv.real_external_port || (config.httpsEnabled ? config.httpsPort : config.httpPort);
 
 /* Logging */
-config.logLevel = Argv.log_level || Config.log_level;
+config.logLevel = Argv.log_level || Config.log_level || 'info';
 
 config.httpsKey = Argv.https_key || Config.https_key || null;
 config.httpsCert = Argv.https_cert || Config.https_cert || null;
 
 /* Upstream Registry */
-config.upstreamHost = Argv.upstream_host || Config.upstream_host;
-config.upstreamPort = Argv.upstream_port || Config.upstream_port;
-config.upstreamUseHttps = Argv.upstream_use_https || Config.upstream_use_https;
-config.upstreamVerifySSL = Argv.upstream_verify_ssl || Config.upstream_verify_ssl;
+config.upstreamHost = Argv.upstream_host || Config.upstream_host || 'registry.npmjs.org';
+config.upstreamPort = Argv.upstream_port || Config.upstream_port || 80;
+config.upstreamUseHttps = Argv.upstream_use_https || Config.upstream_use_https || false;
+config.upstreamVerifySSL = Argv.upstream_verify_ssl || Config.upstream_verify_ssl || false;
 config.upstreamDBPath = Argv.upstream_db_path || Config.upstream_db_path || '';
 
 /* Caching options */
 config.cache = {};
-config.cacheDir = Argv.cache_dir || Config.cache_dir;
-config.cacheExpiry = Argv.cache_expiry || Config.cache_expiry
-config.cacheMem = Argv.cache_mem || Config.cache_mem
+config.cacheDir = Argv.cache_dir || Config.cache_dir || '/tmp/files';
+config.cacheExpiry = Argv.cache_expiry || Config.cache_expiry || 24 * 60 * 60 * 1000; // 24 Hours
+config.cacheMem = Argv.cache_mem || Config.cache_mem || 200; // MB
 config.cacheOptions = {
     cache: {
         expire: 60 * 60,

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,15 +13,13 @@ var FS = require('fs');
 var Optimist = require('optimist')
 .usage('Usage: $0 -p <port> -a <external_dns> -c <file cache dir>')
 .describe({
-    a: 'The external DNS name this mirror should serve on',
-    b: 'The local interface bind address',
-    c: 'The full directory path the cache directory (no trailing slash)',
-    p: 'The HTTP port for the lazy mirror to listen on',
-    C: 'The path to the JSON configuration file',
+    server_address: 'The external DNS name this mirror should serve on',
+    bind_address: 'The local interface bind address',
+    cache_dir: 'The full directory path the cache directory (no trailing slash)',
+    http_port: 'The HTTP port for the lazy mirror to listen on',
+    config: 'The path to the JSON configuration file',
     cache_expiry: 'Expire the upstream registry cache assets on this value (ms)',
     cache_mem: 'The maxmium size in MB of registry data to keep in memory. A larger allocation reduces disk hits and improves performance',
-    cache_dir: 'The root directory path to store cache objects',
-    config: 'The path to the JSON server configuration file',
     http_enabled: 'Enable the HTTP server on -p, this is true if neither --http_enabled or --https_enabled are supplied',
     https_enabled: 'Enable the HTTPS server on --https_port',
     https_key: 'The path to the private SSL key',
@@ -32,7 +30,6 @@ var Optimist = require('optimist')
     package_blacklist: 'Full path to a JSON configuration file of blacklisted packages',
     permit_stale_resources: 'Continue to serve stale resources if the upstream registry cannot be contacted',
     real_external_port: 'If this mirror is behind a proxy, set this flag to the real external port for client connections',
-    server_address: 'The external DNS name for connecting clients',
     upstream_host: 'The upstream registry host',
     upstream_port: 'The default upstream registry port',
     upstream_db_path: 'The default upstream registry database path, default: none (requires a leading slash)',
@@ -40,10 +37,10 @@ var Optimist = require('optimist')
     upstream_verify_ssl: 'Verify the upstream registry\'s SSL certificates'
 })
 .default({
-    'a': 'localhost',
-    'b': '127.0.0.1',
-    'c': '/tmp/files',
-    'p': 2000,
+    'server_address': 'localhost',
+    'bind_address': '127.0.0.1',
+    'cache_dir': '/tmp/files',
+    'http_port': 2000,
     'cache_expiry': 24 * 60 * 60 * 1000, // 24 Hours
     'cache_mem': 200, // MB
     'https_port': 443,
@@ -51,6 +48,13 @@ var Optimist = require('optimist')
     'upstream_port': 80,
     'upstream_use_https': false,
     'upstream_verify_ssl': false
+})
+.alias({
+    'server_address': 'a',
+    'bind_address': 'b',
+    'cache_dir': 'c',
+    'http_port': 'p',
+    'config': 'C'
 });
 
 var Argv = Optimist.argv,


### PR DESCRIPTION
- Correct README flag for `--cache_dir`
- Correct external DNS flag (`--server_address, -a`) flag in usage message
- Remove duplicate option descriptions, configure as [Optimist aliases](https://github.com/substack/node-optimist#aliaskey-alias)
- Add descriptions for `--help, -h`, `--version, -v`, and `--log_level` options
